### PR TITLE
fixes for some php errors on password change (attempt)

### DIFF
--- a/passwordpolicy/appinfo/application.php
+++ b/passwordpolicy/appinfo/application.php
@@ -16,7 +16,8 @@ class Application extends App {
          */
         $container->registerService('PasswordPolicyHooks', function($c) {
             return new PasswordPolicyHooks(
-		$c->query('ServerContainer')->getUserSession()
+		$c->query('ServerContainer')->getUserSession(),
+                $c->query('Request')
             );
         });
     }

--- a/passwordpolicy/controller/passwordpolicycontroller.php
+++ b/passwordpolicy/controller/passwordpolicycontroller.php
@@ -19,10 +19,11 @@ class PasswordPolicyController extends Controller {
     
     public function validatepassword($password){
 	$response = array();
+        $error = '';
 
 	if(strlen($password) < intval($this->service->getAppValue('minlength')))
 	{
-	    $error = \OC_L10N::get('passwordpolicy')->t('Password is too short. ');
+	    $error .= \OC_L10N::get('passwordpolicy')->t('Password is too short. ');
 	}
 	
 	if($this->service->getAppValue('hasnumbers') == "true")
@@ -51,7 +52,7 @@ class PasswordPolicyController extends Controller {
 	}
 
 	
-	if(isset($error))
+	if(!empty($error))
 	{
             $errormsg = \OC_L10N::get('passwordpolicy')->t('Password does not conform to the Password Policy. [%s]', [ $error ]);
 	    $response = array('status' => "Failure", 'data' => array('message'=>"$errormsg"));

--- a/passwordpolicy/hooks/passwordpolicyhooks.php
+++ b/passwordpolicy/hooks/passwordpolicyhooks.php
@@ -7,18 +7,19 @@ class PasswordPolicyHooks {
 
     private $userManager;
 
-    public function __construct($userManager){
+    public function __construct($userManager, \OCP\IRequest $request){
         $this->userManager = $userManager;
+        $this->Request = $request;
     }
 
     public function register() {
         $callback = function( $user, $password, $recoverPassword) {
 		// your code that executes before password is changed
-		$passwordpolicy = new PasswordPolicyController('passwordpolicy');
+		$passwordpolicy = new PasswordPolicyController('passwordpolicy', $this->Request);
 		    
 		$response = $passwordpolicy->validatepassword($password);
 		    
-		if($response['status'] == 'Failure')
+		if(isset($response['status']) && $response['status'] == 'Failure')
 		{
 			header('Content-Type: application/json');
 			echo json_encode($response);


### PR DESCRIPTION
I have noticed a couple of PHP errors that occurred when I tried to change my password

If password is long enough but something other with the password is wrong, this error will be logged: 

```
Undefined variable: error at [owncloudpath]/apps/passwordpolicy/controller/passwordpolicycontroller.php#32
```

This will be logged on every password change request:

```
Argument 2 passed to OCA\PasswordPolicy\Controller\PasswordPolicyController::__construct() must implement interface OCP\IRequest, none given, called in [owncloudpath]/apps/passwordpolicy/hooks/passwordpolicyhooks.php on line 17 and defined at [owncloudpath]/apps/passwordpolicy/controller/passwordpolicycontroller.php#13
Undefined variable: request at [owncloudpath]/apps/passwordpolicy/controller/passwordpolicycontroller.php#14
Argument 2 passed to OCP\AppFramework\Controller::__construct() must implement interface OCP\IRequest, null given, called in [owncloudpath]/apps/passwordpolicy/controller/passwordpolicycontroller.php on line 14 and defined at [owncloudpath]/lib/public/appframework/controller.php#62
```

If password applies to policy, this error will be logged:

```
Undefined index: status at [owncloudpath]/apps/passwordpolicy/hooks/passwordpolicyhooks.php#21
```

Most of the time I do not know exactly what I'm doing here, but these changes have corrected the error messages. So it would be good if you look, if my changes are ok.
