### PR TITLE
Show useful error message on lost password page

### DIFF
--- a/passwordpolicy/controller/passwordpolicycontroller.php
+++ b/passwordpolicy/controller/passwordpolicycontroller.php
@@ -15,6 +15,7 @@ class PasswordPolicyController extends Controller {
 		
 	$ocConfig = \OC::$server->getConfig();
 	$this->service = new PasswordPolicyService($ocConfig,'passwordpolicy');
+	$this->request = $request;
     }
     
     public function validatepassword($password){
@@ -55,7 +56,11 @@ class PasswordPolicyController extends Controller {
 	if(!empty($error))
 	{
             $errormsg = \OC_L10N::get('passwordpolicy')->t('Password does not conform to the Password Policy. [%s]', [ $error ]);
-	    $response = array('status' => "Failure", 'data' => array('message'=>"$errormsg"));
+	    if($this->request->server['PATH_INFO'] == "/settings/personal/changepassword"){
+		$response = array('status' => "Failure", 'data' => array('message'=>"$errormsg"));
+	    } else {
+		$response = array('status' => "Failure", 'msg' => "$errormsg");
+	    }
 	}
 	
 	return $response;


### PR DESCRIPTION
Fix for #4 
With this change the user gets more information if the password reset fails because it does not comply with the policy.
