### PR TITLE
Move parent object so that anchor is still working

### DIFF
--- a/passwordpolicy/js/user.js
+++ b/passwordpolicy/js/user.js
@@ -1,4 +1,4 @@
 
 $(document).ready(function() {
-	$('#passwordform').after($('#password_policy').detach());
+	$('#passwordform').after($('#password_policy').parent().detach());
 });


### PR DESCRIPTION
If the user is in the settings menu click on password policy only scrolls down.
With this change the parent div is moved and click on password policy is working.
